### PR TITLE
Fix TextBoxHelper code smells

### DIFF
--- a/Miru/Views/TextBoxHelper.cs
+++ b/Miru/Views/TextBoxHelper.cs
@@ -1,14 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 
 namespace Miru.Views
 {
+    // TODO: add unit tests
     public class TextBoxHelper : DependencyObject
     {
         public class MvvmCommand : DependencyObject, ICommand

--- a/Miru/Views/TextBoxHelper.cs
+++ b/Miru/Views/TextBoxHelper.cs
@@ -18,20 +18,17 @@ namespace Miru.Views
             public event EventHandler CanExecuteChanged;
             public MvvmCommand(Action<object> execute, Func<object, bool> canExecute = null)
             {
-                if (execute == null) throw new ArgumentNullException("command");
-                _canExecute = canExecute == null ? parmeter => MvvmCommand.AlwaysCanExecute() : canExecute;
+                if (execute == null) throw new ArgumentNullException("execute");
+                _canExecute = canExecute == null ? parmeter => AlwaysCanExecute : canExecute;
                 _execute = execute;
             }
             public object Tag
             {
-                get { return (object)GetValue(TagProperty); }
+                get { return GetValue(TagProperty); }
                 set { SetValue(TagProperty, value); }
             }
             public static readonly DependencyProperty TagProperty = DependencyProperty.Register("Tag", typeof(object), typeof(MvvmCommand), new PropertyMetadata(null));
-            static bool AlwaysCanExecute()
-            {
-                return true;
-            }
+            const bool AlwaysCanExecute = true;
             public void EvaluateCanExecute()
             {
                 EventHandler temp = CanExecuteChanged;
@@ -44,7 +41,7 @@ namespace Miru.Views
             }
             public virtual bool CanExecute(object parameter)
             {
-                return _canExecute == null ? true : _canExecute(parameter);
+                return _canExecute == null || _canExecute(parameter);
             }
         }
 


### PR DESCRIPTION
- Fix parameter name
- Remove unnecessary cast
- Remove the `AlwaysCanExecute` method and declare a constant instead
- Remove unnecessary Boolean literal
- Remove unnecessary usings
- Add TODO comment for unit tests for this class