### PR TITLE
Add MvvmCommand test class

### DIFF
--- a/Miru.Tests/ViewsTests/MvvmCommandTests.cs
+++ b/Miru.Tests/ViewsTests/MvvmCommandTests.cs
@@ -1,0 +1,27 @@
+﻿using Miru.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Miru.Tests.ViewsTests
+{
+    public class MvvmCommandTests
+    {
+        [Fact]
+        public void Constructor_GivenNullExecute_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>("execute", () => new MvvmCommand(null));
+        }
+
+        [Fact]
+        public void Constructor_GivenNullCanExecute_SetCanExecuteTrue()
+        {
+            var sut = new MvvmCommand(x => { }, null);
+            
+            Assert.True(sut._canExecute(null));
+        }
+    }
+}

--- a/Miru/Properties/AssemblyInfo.cs
+++ b/Miru/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -13,7 +14,7 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © Iyarashii 2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
+[assembly: InternalsVisibleTo("Miru.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/Miru/Views/MvvmCommand.cs
+++ b/Miru/Views/MvvmCommand.cs
@@ -12,26 +12,24 @@ namespace Miru.Views
         public event EventHandler CanExecuteChanged;
         public MvvmCommand(Action<object> execute, Func<object, bool> canExecute = null)
         {
-            if (execute == null) throw new ArgumentNullException("execute");
-            _canExecute = canExecute == null ? parmeter => AlwaysCanExecute : canExecute;
-            _execute = execute;
+            _execute = execute ?? throw new ArgumentNullException("execute");
+            _canExecute = canExecute ?? (parmeter => AlwaysCanExecute);
         }
         public object Tag
         {
             get { return GetValue(TagProperty); }
             set { SetValue(TagProperty, value); }
         }
-        public static readonly DependencyProperty TagProperty = DependencyProperty.Register("Tag", typeof(object), typeof(MvvmCommand), new PropertyMetadata(null));
+        public static readonly DependencyProperty TagProperty = DependencyProperty
+            .Register("Tag", typeof(object), typeof(MvvmCommand), new PropertyMetadata(null));
         const bool AlwaysCanExecute = true;
         public void EvaluateCanExecute()
         {
-            EventHandler temp = CanExecuteChanged;
-            if (temp != null)
-                temp(this, EventArgs.Empty);
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
         }
         public virtual void Execute(object parameter)
         {
-            _execute(parameter == null ? this : parameter);
+            _execute(parameter ?? this);
         }
         public virtual bool CanExecute(object parameter)
         {

--- a/Miru/Views/MvvmCommand.cs
+++ b/Miru/Views/MvvmCommand.cs
@@ -8,7 +8,7 @@ namespace Miru.Views
     public class MvvmCommand : DependencyObject, ICommand
     {
         readonly Action<object> _execute;
-        readonly Func<object, bool> _canExecute;
+        internal readonly Func<object, bool> _canExecute;
         public event EventHandler CanExecuteChanged;
         public MvvmCommand(Action<object> execute, Func<object, bool> canExecute = null)
         {

--- a/Miru/Views/TextBoxHelper.cs
+++ b/Miru/Views/TextBoxHelper.cs
@@ -4,7 +4,6 @@ using System.Windows.Input;
 
 namespace Miru.Views
 {
-    // TODO: add unit tests
     public class TextBoxHelper : DependencyObject
     {
         public static KeyGesture GetFocusGesture(DependencyObject obj)


### PR DESCRIPTION
- Refactor and add test class for the `MvvmCommand` class.
- Remove the **TODO** comment that is completed.
- Add assembly attribute to `Miru` to make internals visible to `Miru.Tests` assembly.