### PR TITLE
Remove db migrations from code coverage

### DIFF
--- a/MiruDatabaseLogicLayer/Data/Migrations/202001251554307_AddSyncedUsersTable.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202001251554307_AddSyncedUsersTable.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class AddSyncedUsersTable : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202001252346182_AddAnimeAiringTimesTable.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202001252346182_AddAnimeAiringTimesTable.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class AddAnimeAiringTimesTable : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202001261232547_ModifyAnimeAiringTimeModel.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202001261232547_ModifyAnimeAiringTimeModel.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class ModifyAnimeAiringTimeModel : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202002101159035_RenameAnimeAiringTimesTable.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202002101159035_RenameAnimeAiringTimesTable.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class RenameAnimeAiringTimesTable : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202002181240582_UpdateMiruAiringAnimeModel.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202002181240582_UpdateMiruAiringAnimeModel.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class UpdateMiruAiringAnimeModel : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202003151434418_AddCurrentlyAiringFlag.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202003151434418_AddCurrentlyAiringFlag.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class AddCurrentlyAiringFlag : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202003151920351_AddAnimeType.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202003151920351_AddAnimeType.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     public partial class AddAnimeType : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202004091158179_AddLocalImagePathToMiruAnimeModel.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202004091158179_AddLocalImagePathToMiruAnimeModel.cs
@@ -6,7 +6,9 @@ namespace MiruDatabaseLogicLayer.Migrations
 {
     using System;
     using System.Data.Entity.Migrations;
-    
+    using System.Diagnostics.CodeAnalysis;
+
+    [ExcludeFromCodeCoverage]
     public partial class AddLocalImagePathToMiruAnimeModel : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202006071325437_RenameToMiruAnimeModelsColumn.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202006071325437_RenameToMiruAnimeModelsColumn.cs
@@ -6,7 +6,9 @@ namespace MiruDatabaseLogicLayer.Migrations
 {
     using System;
     using System.Data.Entity.Migrations;
-    
+    using System.Diagnostics.CodeAnalysis;
+
+    [ExcludeFromCodeCoverage]
     public partial class RenameToMiruAnimeModelsColumn : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/202104171832312_AddIsOnSenpaiField.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/202104171832312_AddIsOnSenpaiField.cs
@@ -6,7 +6,9 @@ namespace MiruDatabaseLogicLayer.Migrations
 {
     using System;
     using System.Data.Entity.Migrations;
-    
+    using System.Diagnostics.CodeAnalysis;
+
+    [ExcludeFromCodeCoverage]
     public partial class AddIsOnSenpaiField : DbMigration
     {
         public override void Up()

--- a/MiruDatabaseLogicLayer/Data/Migrations/Configuration.cs
+++ b/MiruDatabaseLogicLayer/Data/Migrations/Configuration.cs
@@ -5,7 +5,9 @@
 namespace MiruDatabaseLogicLayer.Migrations
 {
     using System.Data.Entity.Migrations;
+    using System.Diagnostics.CodeAnalysis;
 
+    [ExcludeFromCodeCoverage]
     internal sealed class Configuration : DbMigrationsConfiguration<MiruDatabaseLogicLayer.MiruDbContext>
     {
         public Configuration()


### PR DESCRIPTION
Remove DB migrations generated by Entity Framework and DB migration configuration file from code coverage for now.