### PR TITLE
Add test for less than 300 dropped animes

### DIFF
--- a/Miru.Tests/ModelsTests/CurrentUserAnimeListModelTests.cs
+++ b/Miru.Tests/ModelsTests/CurrentUserAnimeListModelTests.cs
@@ -78,5 +78,34 @@ namespace Miru.Tests.ModelsTests
                 Assert.Equal(expectedErrorMessage, errorMessage);
             }
         }
+
+        [Theory]
+        [InlineData(50)]
+        [InlineData(299)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task GetCurrentUserDroppedAnimeList_LessThan300DroppedAnimes_ReturnTrueAndCorrectCount(int expectedDroppedAnimeCount)
+        {
+            using (var mock = AutoMock.GetLoose())
+            {
+                // Arrange
+                var testData = new UserAnimeList
+                {
+                    Anime = new AnimeListEntry[expectedDroppedAnimeCount]
+                };
+                mock.Mock<IJikan>()
+                    .Setup(x => x.GetUserAnimeList(It.IsAny<string>(), UserAnimeListExtension.Dropped, It.IsAny<int>()))
+                    .ReturnsAsync(testData);
+                var sut = mock.Create<CurrentUserAnimeListModel>();
+
+                // Act
+                var (result, errorMessage) = await sut.GetCurrentUserDroppedAnimeList(It.IsAny<string>());
+
+                // Assert
+                Assert.True(result);
+                Assert.Equal(string.Empty, errorMessage);
+                Assert.Equal(expectedDroppedAnimeCount, sut.UserDroppedAnimeListData.Anime.Count);
+            }
+        }
     }
 }

--- a/MiruLibrary/Models/CurrentUserAnimeListModel.cs
+++ b/MiruLibrary/Models/CurrentUserAnimeListModel.cs
@@ -51,11 +51,14 @@ namespace MiruLibrary.Models
                 UserDroppedAnimeListData = await JikanWrapper
                     .GetUserAnimeList(malUsername, UserAnimeListExtension.Dropped, page++);
 
-                while (UserDroppedAnimeListData.Anime.Count % maxPageSize == 0)
+                while (UserDroppedAnimeListData.Anime.Count > 0 && 
+                       UserDroppedAnimeListData.Anime.Count % maxPageSize == 0)
                 {
                     var nextDroppedAnimeListPage = await JikanWrapper
                         .GetUserAnimeList(malUsername, UserAnimeListExtension.Dropped, page++);
-                    UserDroppedAnimeListData.Anime = UserDroppedAnimeListData.Anime.Concat(nextDroppedAnimeListPage.Anime).ToArray();
+                    UserDroppedAnimeListData.Anime = UserDroppedAnimeListData.Anime
+                                                                             .Concat(nextDroppedAnimeListPage.Anime)
+                                                                             .ToArray();
                 }
             }
             catch (Exception)

--- a/MiruLibrary/Models/CurrentUserAnimeListModel.cs
+++ b/MiruLibrary/Models/CurrentUserAnimeListModel.cs
@@ -5,7 +5,6 @@
 using JikanDotNet;
 using System;
 using System.Linq;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace MiruLibrary.Models


### PR DESCRIPTION
Add a condition that ensures not to enter the loop when there is 0 dropped anime on the 1st page.