### PR TITLE
Select all text after focus gesture

### DIFF
--- a/Miru.Tests/ViewsTests/TextBoxHelperTests.cs
+++ b/Miru.Tests/ViewsTests/TextBoxHelperTests.cs
@@ -4,6 +4,7 @@
 
 using Miru.Views;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using Xunit;
 
@@ -57,18 +58,20 @@ namespace Miru.Tests.ViewsTests
         }
 
         [StaFact]
-        public void FocusCommand_GivenMvvmCommand_FocusTag()
+        public void FocusCommand_GivenMvvmCommand_FocusTagAndSelectAllText()
         {
+            var testText = "3939";
             var testData = new MvvmCommand(x => { })
             {
-                Tag = new UIElement()
+                Tag = new TextBox() { Text = testText}
             };
-            (testData.Tag as UIElement).Focusable = true;
-            (testData.Tag as UIElement).IsEnabled = true;
+            (testData.Tag as TextBox).Focusable = true;
+            (testData.Tag as TextBox).IsEnabled = true;
 
             TextBoxHelper.FocusCommand(testData);
 
-            Assert.True((testData.Tag as UIElement).IsFocused);
+            Assert.True((testData.Tag as TextBox).IsFocused);
+            Assert.Equal(testText, (testData.Tag as TextBox).SelectedText);
         }
 
         [StaFact]

--- a/Miru/Views/TextBoxHelper.cs
+++ b/Miru/Views/TextBoxHelper.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 
 namespace Miru.Views
@@ -41,7 +42,10 @@ namespace Miru.Views
         public static void FocusCommand(object parameter)
         {
             if (parameter is MvvmCommand targetCommand && targetCommand.Tag is UIElement targetElement)
+            {
                 targetElement.Focus();
+                (targetElement as TextBox).SelectAll();
+            }
         }
     }
 }


### PR DESCRIPTION
After using CTRL+F or CTRL+M to focus text boxes select all text of the text box.