### PR TITLE
Add xUnit test logger

### DIFF
--- a/Miru.Tests/Miru.Tests.csproj
+++ b/Miru.Tests/Miru.Tests.csproj
@@ -49,6 +49,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
+    <PackageReference Include="XunitXml.TestLogger" Version="3.0.78" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With this change it is possible to use this:
`dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover --logger:"xunit;LogFileName=G:/repos/Miru/XUnitResults.xml"` 
instead of using `packages\xunit.runner.console.2.4.1\tools\net472\xunit.console.exe G:\repos\Miru\Miru.Tests\bin\Debug\net472\Miru.Tests.dll -xml XUnitResults.xml` for xUnit test results.