### PR TITLE
Remove duplicate save settings

### DIFF
--- a/Miru/Bootstrapper.cs
+++ b/Miru/Bootstrapper.cs
@@ -91,18 +91,8 @@ namespace Miru
 
         protected override void OnExit(object sender, EventArgs e)
         {
-            SaveSettings();
+            Container.Resolve<IShellViewModel>().SaveSettings(false);
             base.OnExit(sender, e);
-        }
-        // TODO: Reduce Container.Resolve calls and try to reuse the code in ShellViewModel SaveSettings so that 2 methods don't have to be updated
-        private void SaveSettings()
-        {
-            Container.Resolve<UserSettings>().AnimeImageSize = Container.Resolve<IShellViewModel>().AnimeImageSizeInPixels;
-            Container.Resolve<UserSettings>().DisplayedAnimeListType = Container.Resolve<IShellViewModel>().SelectedDisplayedAnimeList;
-            Container.Resolve<UserSettings>().DisplayedAnimeType = Container.Resolve<IShellViewModel>().SelectedDisplayedAnimeType;
-            Container.Resolve<UserSettings>().GetDroppedAnimeData = Container.Resolve<IShellViewModel>().GetDroppedAnimeData;
-            Container.Resolve<UserSettings>().WatchingStatusHighlightOpacity = Container.Resolve<IShellViewModel>().WatchingStatusHighlightOpacity;
-            Container.Resolve<ISettingsWriter>().Write(Container.Resolve<UserSettings>());
         }
     }
 }

--- a/Miru/ViewModels/Interfaces/IShellViewModel.cs
+++ b/Miru/ViewModels/Interfaces/IShellViewModel.cs
@@ -67,5 +67,6 @@ namespace Miru.ViewModels
         Task<bool> SaveAnimeListData(bool isSeasonSyncOn);
         void UpdateUiAfterDataSync();
         Task<bool> GetUserDroppedAnimeList();
+        void SaveSettings(bool displayToastNotification);
     }
 }

--- a/Miru/ViewModels/ShellViewModel.cs
+++ b/Miru/ViewModels/ShellViewModel.cs
@@ -715,7 +715,7 @@ namespace Miru.ViewModels
         }
 
         // event handler for Save settings button
-        public void SaveSettings()
+        public void SaveSettings(bool displayToastNotification)
         {
             UpdateAppStatus(MiruAppStatus.Busy);
             UserSettings.AnimeImageSize = AnimeImageSizeInPixels;
@@ -725,7 +725,8 @@ namespace Miru.ViewModels
             UserSettings.WatchingStatusHighlightOpacity = WatchingStatusHighlightOpacity;
             _settingsWriter.Write(UserSettings);
             UpdateAppStatus(MiruAppStatus.Idle);
-            ToastNotifierWrapper.DisplayToastNotification("Settings saved!");
+            if (displayToastNotification)
+                ToastNotifierWrapper.DisplayToastNotification("Settings saved!");
         }
         #endregion event handlers and guard methods
         internal string GetSongTitleAndArtistName(string input)

--- a/Miru/Views/ShellView.xaml
+++ b/Miru/Views/ShellView.xaml
@@ -325,6 +325,13 @@
                         IsEnabled="{Binding CanChangeDisplayedAnimeList}"
                         Margin="10,13,0,0"
                         Content="Save Settings">
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="Click">
+                            <cal:ActionMessage MethodName="SaveSettings">
+                                <cal:Parameter Value="True" />
+                            </cal:ActionMessage>
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
                 </Button>
             </WrapPanel>
         </StackPanel>


### PR DESCRIPTION
Reduce code duplication by using save settings from shell view model on close.
- Add bool flag for toast notif
- Update caliburn xaml binding for button