### PR TITLE
Enhance handling of anime with no airing date

### DIFF
--- a/Miru/ViewModels/Interfaces/ISortedAnimeListsViewModel.cs
+++ b/Miru/ViewModels/Interfaces/ISortedAnimeListsViewModel.cs
@@ -18,6 +18,7 @@ namespace Miru.ViewModels
         IEnumerable<MiruAnimeModel> ThursdayAiringAnimeList { get; set; }
         IEnumerable<MiruAnimeModel> TuesdayAiringAnimeList { get; set; }
         IEnumerable<MiruAnimeModel> WednesdayAiringAnimeList { get; set; }
+        IEnumerable<MiruAnimeModel> NoAiringDateAnimeList { get; set; }
         IMiruAnimeModelProcessor MiruAnimeModelProcessor { get; }
 
         void SetAnimeSortedByAirDayOfWeekAndFilteredByGivenAnimeListType(IEnumerable<MiruAnimeModel> animeModels, AnimeListType animeListType);

--- a/Miru/ViewModels/SortedAnimeListsViewModel.cs
+++ b/Miru/ViewModels/SortedAnimeListsViewModel.cs
@@ -27,6 +27,7 @@ namespace Miru.ViewModels
         private IEnumerable<MiruAnimeModel> _fridayAiringAnimeList;
         private IEnumerable<MiruAnimeModel> _saturdayAiringAnimeList;
         private IEnumerable<MiruAnimeModel> _sundayAiringAnimeList;
+        private IEnumerable<MiruAnimeModel> _noAiringDateAnimeList;
 
         public IEnumerable<MiruAnimeModel> MondayAiringAnimeList
         {
@@ -74,6 +75,12 @@ namespace Miru.ViewModels
             set { _sundayAiringAnimeList = value; NotifyOfPropertyChange(() => SundayAiringAnimeList); }
         }
 
+        public IEnumerable<MiruAnimeModel> NoAiringDateAnimeList
+        {
+            get { return _noAiringDateAnimeList; }
+            set { _noAiringDateAnimeList = value; NotifyOfPropertyChange(() => NoAiringDateAnimeList); }
+        }
+
         /// <summary>
         /// Assigns animes to the correct day of week airing list properties. 
         /// </summary>
@@ -90,6 +97,7 @@ namespace Miru.ViewModels
             FridayAiringAnimeList = MiruAnimeModelProcessor.FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(animeModels, DayOfWeek.Friday);
             SaturdayAiringAnimeList = MiruAnimeModelProcessor.FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(animeModels, DayOfWeek.Saturday);
             SundayAiringAnimeList = MiruAnimeModelProcessor.FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(animeModels, DayOfWeek.Sunday);
+            NoAiringDateAnimeList = MiruAnimeModelProcessor.FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(animeModels, null);
         }
     }
 }

--- a/Miru/Views/ShellView.xaml
+++ b/Miru/Views/ShellView.xaml
@@ -140,6 +140,7 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="20" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
@@ -344,6 +345,7 @@
         <TextBlock Text="FRIDAY" Grid.Row="2" Grid.Column="5" TextAlignment="Center" Background="{Binding DaysOfTheWeekBrush}" />
         <TextBlock Text="SATURDAY" Grid.Row="2" Grid.Column="6" TextAlignment="Center" Background="{Binding DaysOfTheWeekBrush}" />
         <TextBlock Text="SUNDAY" Grid.Row="2" Grid.Column="7" TextAlignment="Center" Background="{Binding DaysOfTheWeekBrush}" />
+        <TextBlock Text="NO AIR TIME" Grid.Row="2" Grid.Column="8" TextAlignment="Center" Background="{Binding DaysOfTheWeekBrush}" />
 
         <!-- Row 3 -->
         <!-- ############################ Datagrid for anime airing on MONDAY  ############################ -->
@@ -373,5 +375,9 @@
         <!-- ############################ Datagrid for anime airing on SUNDAY  ############################ -->
         <ContentControl Grid.Row="3" Grid.Column="7" Template="{StaticResource AiringAnimeDatagridTemplate}"
                         Content="{Binding SortedAnimeLists.SundayAiringAnimeList}" />
+        
+        <!-- ############################ Datagrid for anime with no airing date ############################ -->
+        <ContentControl Grid.Row="3" Grid.Column="8" Template="{StaticResource AiringAnimeDatagridTemplate}"
+                        Content="{Binding SortedAnimeLists.NoAiringDateAnimeList}" />
     </Grid>
 </Window>

--- a/MiruLibrary/Models/Interfaces/IMiruAnimeModelProcessor.cs
+++ b/MiruLibrary/Models/Interfaces/IMiruAnimeModelProcessor.cs
@@ -9,7 +9,7 @@ namespace MiruLibrary.Models
 {
     public interface IMiruAnimeModelProcessor
     {
-        IEnumerable<MiruAnimeModel> FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(IEnumerable<MiruAnimeModel> animeModels, DayOfWeek dayOfWeek);
+        IEnumerable<MiruAnimeModel> FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(IEnumerable<MiruAnimeModel> animeModels, DayOfWeek? dayOfWeek);
         IEnumerable<MiruAnimeModel> FilterAnimeModelsByAnimeListType(IEnumerable<MiruAnimeModel> animeModels, AnimeListType animeListType);
     }
 }

--- a/MiruLibrary/Models/MiruAnimeModelExtensions.cs
+++ b/MiruLibrary/Models/MiruAnimeModelExtensions.cs
@@ -60,7 +60,7 @@ namespace MiruLibrary.Models
         {
             if (!anime.JSTBroadcastTime.HasValue)
             {
-                anime.LocalBroadcastTime = DateTime.Today;
+                anime.LocalBroadcastTime = null;
                 return;
             }
             // covert JST to UTC

--- a/MiruLibrary/Models/MiruAnimeModelProcessor.cs
+++ b/MiruLibrary/Models/MiruAnimeModelProcessor.cs
@@ -42,9 +42,16 @@ namespace MiruLibrary.Models
         /// <returns>
         /// List of anime models filtered by the specific day of week and ordered by air time.
         /// </returns>
-        public IEnumerable<MiruAnimeModel> FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(IEnumerable<MiruAnimeModel> animeModels, DayOfWeek dayOfWeek)
+        public IEnumerable<MiruAnimeModel> FilterAnimeModelsByAirDayOfWeekAndOrderByAirTime(IEnumerable<MiruAnimeModel> animeModels, DayOfWeek? dayOfWeek)
         {
-            return animeModels.Where(a => a.LocalBroadcastTime.Value.DayOfWeek == dayOfWeek).OrderBy(s => s.LocalBroadcastTime.Value.TimeOfDay);
+            if (dayOfWeek == null)
+            {
+                return animeModels.Where(a => a.LocalBroadcastTime == null).OrderBy(a => a.Title);
+            }
+            return animeModels
+                .Where(a => a.LocalBroadcastTime.HasValue
+                    && a.LocalBroadcastTime.Value.DayOfWeek == dayOfWeek)
+                .OrderBy(a => a.LocalBroadcastTime.Value.TimeOfDay);
         }
     }
 }


### PR DESCRIPTION
This PR introduces several key changes aimed at improving the application's support for anime without specified airing dates. A new property, `NoAiringDateAnimeList`, has been added across `ISortedAnimeListsViewModel.cs`, `SortedAnimeListsViewModel.cs`, and `ShellView.xaml` to categorize and display these anime separately. The `IMiruAnimeModelProcessor` interface and its `MiruAnimeModelProcessor.cs` implementation have been updated to allow filtering of anime by a nullable `DayOfWeek`, accommodating anime without a defined airing day. UI enhancements in `ShellView.xaml` include additional components for showcasing the `NoAiringDateAnimeList`, ensuring seamless integration into the existing layout. Furthermore, adjustments in `MiruAnimeModelExtensions.cs` modify the `LocalBroadcastTime` handling for anime lacking a JST broadcast time, setting it to `null` to align with the new handling approach. These changes collectively enhance the user experience by providing a more complete and accurate representation of available anime.