### PR TITLE
Update tests to work with recent Local Broadcast Time null changes

### DIFF
--- a/Miru.Tests/DatabaseTests/MiruDbServiceTests.cs
+++ b/Miru.Tests/DatabaseTests/MiruDbServiceTests.cs
@@ -309,7 +309,7 @@ namespace Miru.Tests.DatabaseTests
                 // Assert
                 Assert.All(result, x => Assert.Contains(title, x.Title));
                 Assert.All(result, x => Assert.Contains(x.Type, animeBroadcastTypeDescription));
-                Assert.All(result, x => Assert.Equal(DateTime.Today, x.LocalBroadcastTime));
+                Assert.All(result, x => Assert.Null(x.LocalBroadcastTime));
                 Assert.Equal(expectedFilteredListSize, result.Count);
             }
         }

--- a/Miru.Tests/ModelsTests/MiruAnimeModelExtensionsTests.cs
+++ b/Miru.Tests/ModelsTests/MiruAnimeModelExtensionsTests.cs
@@ -164,7 +164,7 @@ namespace Miru.Tests.ModelsTests
         }
 
         [Fact]
-        public void ConvertJstBroadcastTimeToSelectedTimeZone_GivenEmptyJstBroadcastTime_SetLocalBroadcastTimeForToday()        
+        public void ConvertJstBroadcastTimeToSelectedTimeZone_GivenEmptyJstBroadcastTime_SetLocalBroadcastTimeToNull()        
         {
             // Arrange
             var sut = new MiruAnimeModel { JSTBroadcastTime = null };
@@ -173,7 +173,7 @@ namespace Miru.Tests.ModelsTests
             sut.ConvertJstBroadcastTimeToSelectedTimeZone(It.IsAny<TimeZoneInfo>());
 
             // Assert
-            Assert.True(sut.LocalBroadcastTime == DateTime.Today);
+            Assert.Null(sut.LocalBroadcastTime);
         }
 
         const string TITLE = "takodachis adventure";


### PR DESCRIPTION
#### PR Classification
Code update to modify the handling of `LocalBroadcastTime` in test cases.

#### PR Summary
This pull request updates the handling of `LocalBroadcastTime` in two test files to align with a new approach where the absence of a specific local broadcast time is explicitly indicated by `null`. The changes reflect a strategic update to enhance clarity in the system's handling of undefined broadcast times.
- In `MiruDbServiceTests.cs`, the assertion for `LocalBroadcastTime` now expects `null` instead of `DateTime.Today`.
- In `MiruAnimeModelExtensionsTests.cs`, the test method name and its assertion were updated to reflect the handling of `LocalBroadcastTime` as `null` when `JSTBroadcastTime` is missing.
