### PR TITLE
Do not change list type after sync

### DIFF
--- a/Miru/ViewModels/ShellViewModel.cs
+++ b/Miru/ViewModels/ShellViewModel.cs
@@ -544,8 +544,6 @@ namespace Miru.ViewModels
             // update displayed username and sync date
             MalUserName = TypedInUsername;
 
-            // display sorted animes from user's watching anime list
-            SelectedDisplayedAnimeList = AnimeListType.Watching;
             SelectedTimeZone = TimeZoneInfo.Local;
 
             // update app status


### PR DESCRIPTION
#### PR Classification
Code behavior modification to change UI update logic after data synchronization.

#### PR Summary
The `UpdateUiAfterDataSync` method in `ShellViewModel.cs` no longer defaults to showing the user's watching anime list after a data sync.
- `ShellViewModel.cs`: Removed lines setting `SelectedDisplayedAnimeList` to `AnimeListType.Watching`.
