### PR TITLE
Add right click and a test

### DIFF
--- a/Miru.UiTests/UI/FlaUIWebDriverTests/CopyOpEdTests.cs
+++ b/Miru.UiTests/UI/FlaUIWebDriverTests/CopyOpEdTests.cs
@@ -32,5 +32,27 @@ namespace Miru.UiTests.UI.FlaUIWebDriverTests
                 Assert.Contains(word, animeTitleTextBox.Text);
             }
         }
+
+        [Fact]
+        public void CheckDialogButtonsAfterRightClick()
+        {
+            // Arrange
+            // wait for grids to load
+            Thread.Sleep(2000);
+            var animeTitleTextBox = driver.FindElements(By.XPath("/DataGrid[6]/DataItem[1]/Custom[1]/Text")).FirstOrDefault();
+            Assert.NotNull(animeTitleTextBox);
+
+            // Act
+            RightClick(animeTitleTextBox.Id);
+
+            // Assert
+            var opButton = driver.FindElement(By.Name("OP"));
+            var edButton = driver.FindElement(By.Name("ED"));
+            var cancelButton = driver.FindElement(By.Name("Cancel"));
+            Assert.NotNull(opButton);
+            Assert.NotNull(edButton);
+            Assert.NotNull(cancelButton);
+            cancelButton.Click();
+        }
     }
 }

--- a/Miru.UiTests/UI/FlaUIWebDriverTests/FlaUIWebDriverTestBase.cs
+++ b/Miru.UiTests/UI/FlaUIWebDriverTests/FlaUIWebDriverTestBase.cs
@@ -28,6 +28,16 @@ namespace Miru.UiTests.UI.FlaUIWebDriverTests
             }
         }
 
+        public void RightClick(string elementId)
+        {
+            driver.ExecuteScript(
+                "windows: click", new Dictionary<string, object>()
+                {
+                    { "button", "right" },
+                    { "elementId", elementId }
+                });
+        }
+
         public void Dispose()
         {
             driver.Close();


### PR DESCRIPTION
#### PR Classification
New feature to enhance test coverage by verifying dialog button presence after a right-click action.

#### PR Summary
Added a new test method and a reusable right-click simulation method to improve UI testing.
- `CopyOpEdTests.cs`: Added `CheckDialogButtonsAfterRightClick` to verify dialog buttons after a right-click.
- `FlaUIWebDriverTestBase.cs`: Introduced `RightClick` method to simulate right-click actions on elements by ID.
